### PR TITLE
buildbatch にワイヤレスADB対応を追加

### DIFF
--- a/androidstudio/buildbatch/allexecute.sh
+++ b/androidstudio/buildbatch/allexecute.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+csv_file="$BUILD_BATCH_DIR/models/models.csv"
+build_script=""
+direct_model_name=""
+wireless_target=""
+has_input_file=0
+has_build_type=0
+
+usage() {
+	cat <<'EOF'
+Usage:
+  allexecute.sh [-i csvFile] [-m buildType] [-d modelName] [-w target]
+
+buildType:
+  ReleaseBuild
+  ReleaseInstall
+  ReleaseBuildExecute
+  DebugBuild
+  DebugInstall
+  DebugBuildExecute
+  UnInstall
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-i)
+			csv_file="${2:-}"
+			has_input_file=1
+			shift 2
+			;;
+		-m)
+			case "${2:-}" in
+				ReleaseBuild) build_script="$BUILD_BATCH_DIR/subBatch/rbuild.sh" ;;
+				ReleaseInstall) build_script="$BUILD_BATCH_DIR/subBatch/rinstall.sh" ;;
+				ReleaseBuildExecute) build_script="$BUILD_BATCH_DIR/subBatch/rbuildexec.sh" ;;
+				DebugBuild) build_script="$BUILD_BATCH_DIR/subBatch/dbuild.sh" ;;
+				DebugInstall) build_script="$BUILD_BATCH_DIR/subBatch/dinstall.sh" ;;
+				DebugBuildExecute) build_script="$BUILD_BATCH_DIR/subBatch/dbuildexec.sh" ;;
+				UnInstall) build_script="$BUILD_BATCH_DIR/subBatch/uninstall.sh" ;;
+				*)
+					printf 'Error: unsupported build type: %s\n' "${2:-}" >&2
+					exit 1
+					;;
+			esac
+			has_build_type=1
+			shift 2
+			;;
+		-d)
+			direct_model_name="${2:-}"
+			has_input_file=1
+			shift 2
+			;;
+		-w)
+			wireless_target="${2:-}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			shift
+			;;
+	esac
+done
+
+if [ "$has_input_file" -ne 1 ] || [ "$has_build_type" -ne 1 ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -n "$wireless_target" ]; then
+	if ! wireless_target="$(ensure_adb_target "$wireless_target")"; then
+		exit 1
+	fi
+	export ANDROID_SERIAL="$wireless_target"
+fi
+
+if [ -n "$direct_model_name" ]; then
+	logfile="$(log_file_path "$direct_model_name" "$(basename "$build_script")")"
+	printf '*********** Direct Model [%s] [%s] ***********\n' "$direct_model_name" "$(basename "$build_script")"
+	printf 'Log file: %s\n' "$logfile"
+	run_logged "$logfile" "$build_script" "$direct_model_name"
+	printf 'Build process completed.\n'
+	exit 0
+fi
+
+if [ ! -f "$csv_file" ]; then
+	printf 'Error: CSV file not found: %s\n' "$csv_file" >&2
+	exit 1
+fi
+
+while IFS=, read -r model variant; do
+	model="$(trim_csv_field "$model")"
+	variant="$(trim_csv_field "$variant")"
+	if [ -z "$model" ] || [ -z "$variant" ]; then
+		continue
+	fi
+	logfile="$(log_file_path "$variant" "$(basename "$build_script")")"
+	printf '***********  %s [%s] ***********\n' "$model" "$(basename "$build_script")"
+	printf 'Log file: %s\n' "$logfile"
+	run_logged "$logfile" "$build_script" "$variant"
+done < "$csv_file"
+
+printf 'Build process completed.\n'

--- a/androidstudio/buildbatch/common.sh
+++ b/androidstudio/buildbatch/common.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_BATCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANDROID_STUDIO_DIR="$(cd "$BUILD_BATCH_DIR/.." && pwd)"
+ADB_BIN="${ADB_BIN:-adb}"
+
+sanitize_name() {
+	printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr ' /:' '___' | tr -cd '[:alnum:]_.-'
+}
+
+trim_csv_field() {
+	local value="$1"
+	value="${value%$'\r'}"
+	value="${value#"${value%%[![:space:]]*}"}"
+	value="${value%"${value##*[![:space:]]}"}"
+	printf '%s' "$value"
+}
+
+build_type_name() {
+	local variant="$1"
+	local mode="$2"
+	local first rest
+	first="$(printf '%s' "$variant" | cut -c1 | tr '[:lower:]' '[:upper:]')"
+	rest="${variant#?}"
+	printf '%s%s%s' "$first" "$rest" "$mode"
+}
+
+apk_output_dir() {
+	local variant="$1"
+	local kind="$2"
+	printf '%s/app/build/outputs/apk/%s/%s' "$ANDROID_STUDIO_DIR" "$variant" "$kind"
+}
+
+archive_dir_name() {
+	local kind="$1"
+	local date_str
+	date_str="$(date +%Y%m%d)"
+	printf 'v%s_%s_apk' "$date_str" "$kind"
+}
+
+build_log_dir() {
+	printf '%s/logs' "$BUILD_BATCH_DIR"
+}
+
+log_file_path() {
+	local model_name="$1"
+	local build_name="$2"
+	local stamp
+	stamp="$(date +%Y%m%d_%H%M%S)"
+	printf '%s/%s_%s_%s.log' "$(build_log_dir)" "$stamp" "$(sanitize_name "$model_name")" "$(sanitize_name "$build_name")"
+}
+
+run_logged() {
+	local logfile="$1"
+	shift
+	mkdir -p "$(dirname "$logfile")"
+	"$@" </dev/null 2>&1 | tee -a "$logfile"
+}
+
+archive_apks() {
+	local variant="$1"
+	local kind="$2"
+	local src_dir dest_dir
+	local files=()
+
+	src_dir="$(apk_output_dir "$variant" "$kind")"
+	dest_dir="$BUILD_BATCH_DIR/$(archive_dir_name "$kind")"
+	mkdir -p "$dest_dir"
+
+	shopt -s nullglob
+	files=("$src_dir"/*.apk)
+	shopt -u nullglob
+
+	if [ "${#files[@]}" -eq 0 ]; then
+		printf 'No APK files found: %s\n' "$src_dir" >&2
+		return 1
+	fi
+
+	for apk_file in "${files[@]}"; do
+		local apk_name
+		apk_name="$(basename "$apk_file")"
+		apk_name="${apk_name#app-}"
+		cp -f "$apk_file" "$dest_dir/$apk_name"
+	done
+}
+
+run_gradle() {
+	local task="$1"
+	(
+		cd "$ANDROID_STUDIO_DIR"
+		bash ./gradlew "$task"
+	)
+}
+
+start_app() {
+	local variant="$1"
+	adb shell am start -n "jp.matrix.shikarunochi.emulator.${variant}/jp.matrix.shikarunochi.emulator.EmulatorActivity"
+}
+
+uninstall_app() {
+	local variant="$1"
+	"$ADB_BIN" uninstall "jp.matrix.shikarunochi.emulator.${variant}"
+}
+
+ensure_adb_target() {
+	local target="$1"
+	local resolved_target="$target"
+	local device_line
+
+	case "$target" in
+		*:* ) ;;
+		* ) resolved_target="${target}:5555" ;;
+	esac
+
+	device_line="$("$ADB_BIN" devices -l | awk -v t="$resolved_target" '$1 == t { print $0 }')"
+	if [ -n "$device_line" ]; then
+		printf '%s\n' "$resolved_target"
+		return 0
+	fi
+
+	printf 'Connecting ADB target: %s\n' "$resolved_target"
+	if "$ADB_BIN" connect "$resolved_target" >/dev/null 2>&1; then
+		device_line="$("$ADB_BIN" devices -l | awk -v t="$resolved_target" '$1 == t { print $0 }')"
+		if [ -n "$device_line" ]; then
+			printf '%s\n' "$resolved_target"
+			return 0
+		fi
+	fi
+
+	printf 'Warning: ADB target is not available: %s\n' "$resolved_target" >&2
+	return 1
+}

--- a/androidstudio/buildbatch/subBatch/dbuild.bat
+++ b/androidstudio/buildbatch/subBatch/dbuild.bat
@@ -29,7 +29,12 @@ if not exist "%FOLDERNAME%" (
 
 :: APKファイルを新しいフォルダにコピー
 :: 以下のパスはプロジェクトの構成により適宜調整
-copy "..\app\build\outputs\apk\%VARIANT%\debug\*.apk" "%FOLDERNAME%"
+for %%F in ("..\app\build\outputs\apk\%VARIANT%\debug\*.apk") do (
+    set APKNAME=%%~nF
+    if /I "!APKNAME:~0,4!"=="app-" set APKNAME=!APKNAME:~4!
+    copy "%%F" "%FOLDERNAME%\!APKNAME!.apk" >nul
+    if errorlevel 1 goto end
+)
 if %ERRORLEVEL% neq 0 goto end
 
 :end

--- a/androidstudio/buildbatch/subBatch/dbuild.sh
+++ b/androidstudio/buildbatch/subBatch/dbuild.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Debug)"
+run_gradle "assemble${build_type}"
+archive_apks "$variant" debug

--- a/androidstudio/buildbatch/subBatch/dbuildexec.sh
+++ b/androidstudio/buildbatch/subBatch/dbuildexec.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Debug)"
+run_gradle "assemble${build_type}"
+run_gradle "install${build_type}"
+start_app "$variant"
+archive_apks "$variant" debug

--- a/androidstudio/buildbatch/subBatch/dinstall.sh
+++ b/androidstudio/buildbatch/subBatch/dinstall.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Debug)"
+run_gradle "install${build_type}"

--- a/androidstudio/buildbatch/subBatch/rbuild.bat
+++ b/androidstudio/buildbatch/subBatch/rbuild.bat
@@ -29,7 +29,12 @@ if not exist "%FOLDERNAME%" (
 
 :: APKファイルを新しいフォルダにコピー
 :: 以下のパスはプロジェクトの構成により適宜調整
-copy "..\app\build\outputs\apk\%VARIANT%\release\*.apk" "%FOLDERNAME%"
+for %%F in ("..\app\build\outputs\apk\%VARIANT%\release\*.apk") do (
+    set APKNAME=%%~nF
+    if /I "!APKNAME:~0,4!"=="app-" set APKNAME=!APKNAME:~4!
+    copy "%%F" "%FOLDERNAME%\!APKNAME!.apk" >nul
+    if errorlevel 1 goto end
+)
 if %ERRORLEVEL% neq 0 goto end
 
 :end

--- a/androidstudio/buildbatch/subBatch/rbuild.sh
+++ b/androidstudio/buildbatch/subBatch/rbuild.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Release)"
+run_gradle "assemble${build_type}"
+archive_apks "$variant" release

--- a/androidstudio/buildbatch/subBatch/rbuildexec.bat
+++ b/androidstudio/buildbatch/subBatch/rbuildexec.bat
@@ -33,6 +33,11 @@ if not exist "%FOLDERNAME%" (
 
 :: APKファイルを新しいフォルダにコピー
 :: 以下のパスはプロジェクトの構成により適宜調整
-copy "..\app\build\outputs\apk\%VARIANT%\release\*.apk" "%FOLDERNAME%"
+for %%F in ("..\app\build\outputs\apk\%VARIANT%\release\*.apk") do (
+    set APKNAME=%%~nF
+    if /I "!APKNAME:~0,4!"=="app-" set APKNAME=!APKNAME:~4!
+    copy "%%F" "%FOLDERNAME%\!APKNAME!.apk" >nul
+    if errorlevel 1 goto end
+)
 
 endlocal

--- a/androidstudio/buildbatch/subBatch/rbuildexec.sh
+++ b/androidstudio/buildbatch/subBatch/rbuildexec.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Release)"
+run_gradle "assemble${build_type}"
+run_gradle "install${build_type}"
+start_app "$variant"
+archive_apks "$variant" release

--- a/androidstudio/buildbatch/subBatch/rinstall.sh
+++ b/androidstudio/buildbatch/subBatch/rinstall.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+build_type="$(build_type_name "$variant" Release)"
+run_gradle "install${build_type}"

--- a/androidstudio/buildbatch/subBatch/uninstall.sh
+++ b/androidstudio/buildbatch/subBatch/uninstall.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+variant="${1:-}"
+if [ -z "$variant" ]; then
+	printf 'Usage: %s <variant>\n' "${0##*/}" >&2
+	exit 1
+fi
+
+uninstall_app "$variant"


### PR DESCRIPTION
androidstudio/buildbatch に -w オプションを追加し、対象端末へ自動接続してからデプロイできるようにしました。

主な内容:
- allexecute.sh に -w target を追加
- adb connect 失敗時は warning を出して終了
- 接続済みターゲットを ANDROID_SERIAL に流して以後の処理を統一
- buildbatch の shell 一式をこのブランチへ復帰
- APK アーカイブ時の app- プレフィックスを除去